### PR TITLE
fix installation of mongodb & document running tests with docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - echo "TRAVIS_JOB_ID=${TRAVIS_JOB_ID}" > .env
   - echo "TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}" > .env
   - echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}" > .env
-  - sudo docker build -f Dockerfile-base . -t "ubuntu16.04-updated" --no-cache"
+  - sudo docker build -f Dockerfile-base . -t "ubuntu16.04-updated" --no-cache
   - sudo docker-compose build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - echo "TRAVIS_JOB_ID=${TRAVIS_JOB_ID}" > .env
   - echo "TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}" > .env
   - echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}" > .env
-  - sudo docker build -f Dockerfile-base . -t "ubuntu16.04-updated"
+  - sudo docker build -f Dockerfile-base . -t "ubuntu16.04-updated" --no-cache"
   - sudo docker-compose build
 
 script:
@@ -35,7 +35,7 @@ script:
   - sudo docker-compose up --exit-code-from nota
   # - ./node_modules/.bin/eslint ../* this is not inside the docker context so it
   # won't run properly with travis ci
-  - sudo rm -rf database_vol_dir/mongod.lock
+  - sudo rm -rf database_vol_dir/
   - sudo docker-compose ps
 
 # after_script:

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,3 +1,4 @@
 FROM ubuntu:16.04
 
-RUN apt update -y && apt upgrade -y && apt full-upgrade -y && apt install git -y;
+RUN apt update -y && apt upgrade -y && apt full-upgrade -y && apt install git \
+  apt-transport-https ca-certificates -y && apt autoclean -y;

--- a/Dockerfile-mongodb
+++ b/Dockerfile-mongodb
@@ -1,7 +1,6 @@
 FROM ubuntu16.04-updated
 
-RUN echo 'deb [trusted=yes] http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list && \
-    apt update && apt install mongodb -y;
+RUN apt install mongodb -y;
 
 # create default data directory
 RUN mkdir -p /data/db

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ to use it to quickly get your development environment setup.
 the commands below.
 
    ```
-   echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+   apt install mongodb -y
    sudo apt-get update
    sudo apt-get install mongodb -y
    ```
@@ -198,14 +198,35 @@ I recommend testing sending emails to yourself in Mailgun's sandbox mode before
 implementing emails for production. You may find more information about [Mailgun](https://www.mailgun.com/)
 on it's site.
 
-# Routes
+## Routes
 
 This backend allows the user to register, login, logout, reset password, create tasks, retrieve tasks, edit tasks, and delete tasks.
 
 ![](https://github.com/jaylenw/nota/raw/master/screenshots/current-routes.png)
 
+
+## Using Docker for Running Tests (WIP)
+
+**1.)** Build the Ubuntu base image by running the following:
+
+`docker build -f Dockerfile-base . -t "ubuntu16.04-updated" --no-cache"`
+
+**2.)** Build the nota and database containers with docker-compose:
+
+`docker-compose build`
+
+**3.)** Run the following docker compose command to run the tests:
+
+`docker-compose up`
+
+**4.)** After the tests are completed, run the following to remove the database related directory:
+
+`sudo rm -rf database_vol_dir/`
+
+See issue [#85](https://github.com/jaylenw/nota/issues/85).
+
 -------------------------------------------------------------------------------
-## Contributing
+# Contributing
 
 Pull request and issues are welcomed. Please make sure you are able to run the
 unit tests with all passing before raising a PR. Add or modify unit tests sensibly


### PR DESCRIPTION
### What does this PR do?

This pull requests changes the way mongodb is installed as the previous link to install the db is no longer valid. Info has been added to the readme to allow running tests with docker locally.

This PR is related to:
#93 
#84 