### PR TITLE
Provide additions to mark milestone of adding GitHub actions

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     # This step checks out a copy of your repository.
     - uses: actions/checkout@v1
-    # This step adds node setup with version 6
+    # This step adds node setup with version 8
     - uses: actions/setup-node@v1
       with:
         node-version: '8.x'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ script:
   # shutdown cleanly. We will also run eslint to make sure all code is up
   # to standards.
   - sudo docker-compose up --exit-code-from nota
-  # - ./node_modules/.bin/eslint ../* this is not inside the docker context so it
-  # won't run properly with travis ci
   - sudo rm -rf database_vol_dir/
   - sudo docker-compose ps
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# Nota (TodoDoBackend) [![Build Status](https://travis-ci.org/jaylenw/nota.svg?branch=master)](https://travis-ci.org/jaylenw/nota) [![Coverage Status](https://coveralls.io/repos/github/jaylenw/nota/badge.svg?branch=master)](https://coveralls.io/github/jaylenw/nota?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/jaylenw/nota.svg)](https://greenkeeper.io/)
+# Nota (TodoDoBackend) [![Build Status](https://travis-ci.org/jaylenw/nota.svg?branch=master)](https://travis-ci.org/jaylenw/nota) [![Coverage Status](https://coveralls.io/repos/github/jaylenw/nota/badge.svg?branch=master)](https://coveralls.io/github/jaylenw/nota?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/jaylenw/nota.svg)](https://greenkeeper.io/) [![GitHub Action](https://github.com/jaylenw/nota/workflows/ESLINT/badge.svg)](https://github.com/jaylenw/nota/actions)
 
 ![](https://github.com/jaylenw/nota/raw/master/screenshots/nota.png)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds milestone additions for adding GitHub actions to run ESLINT linter on the code.
A readme badge is added and comments were refined.

### PR is related to?

This PR is related to issue #92 

As well, commits pushed directly to `master` (2dc53555e839ca65fc2490ffeccb6bad540d303d, 5808e1bb7c37ac6571bb9e2b10b7105738eed218, e340d0f97e0f222f1346c95d5201407310ade621, 518b8b503d3c7f00ce845aa717247c51953d9084, c298ab346ff41ef89f62217ab767ab67e1466837, f10d999fa657a3eca8feb1aa2e74fa8c6b2236b1) and  PRs, #97 #98 #99 

close #92 