### PR TITLE
chore(travis-deploy): add ability to push an image with `latest` for deployment

### DIFF
--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -5,8 +5,8 @@ environment=$1
 commit_hash="$(git rev-parse --short HEAD)"
 
 if [[ $environment = "dev" || $environment = "prod" ]]; then
-  # build an image for deployment from the deployment stage
-  sudo docker build --target deployment -t notaorg/nota-$environment:$commit_hash .
+  # build images for deployment from the deployment stage, one with commit hash and the other with "latest"
+  sudo docker build --target deployment -t notaorg/nota-$environment:$commit_hash -t notaorg/nota-$environment:latest .
   echo "Docker build completed with exit status of "$?
   # login to docker hub
   echo $DOCKER_ACCESS_TOKEN | sudo docker login --username $DOCKER_USERNAME --password-stdin
@@ -15,7 +15,16 @@ if [[ $environment = "dev" || $environment = "prod" ]]; then
   sudo docker push notaorg/nota-$environment:$commit_hash
   # store the last command's status code
   push_command_status=$?
-  echo "Docker push to registry for the $environment environment completed with exit status of "$push_command_status
+  if [[ $push_command_status -ne 0 ]]; then
+    # exit the script with non-zero exit status code as one of the docker commands above failed
+    echo "Docker failed to push the first image with status code of "$push_command_status
+    exit $push_command_status
+  fi
+  # push and tag with "latest"
+  sudo docker push notaorg/nota-$environment:latest
+  # store the last command's status code
+  push_command_status=$?
+  echo "Docker push to registry for the $environment environment with two tags completed with exit status of "$push_command_status
   exit $push_command_status # return status code of the push command
 else
   echo "Invalid environment string passed. Either 'dev' or 'prod'."


### PR DESCRIPTION
### What does this PR do?

This PR modifies the `travis_deploy.sh` script to allow the push of a image with the `latest` tag when we create an image for dev or prod.

### Issue this PR is related to?

This PR is related to #120 
close #120