### PR TITLE
chore(docker): implement CD w/ docker-compose & watchtower

### DIFF
--- a/docker-compose-deploy-dev.yml
+++ b/docker-compose-deploy-dev.yml
@@ -15,7 +15,8 @@ services:
       - FROM_HEADER=${FROM_HEADER} # from header, shows subject and sender address
       - MAILGUN_API_KEY=${MAILGUN_API_KEY} # mailgun api
       - MAILGUN_DOMAIN=${MAILGUN_DOMAIN} # mailgun key
-    container_name: notadev
+    container_name: notadev # restarts container unless we explicitly stop it
+    restart: unless-stopped
   watchtower:
     image: containrrr/watchtower
     volumes:
@@ -27,3 +28,4 @@ services:
     environment:
       - WATCHTOWER_NOTIFICATIONS=slack
       - WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL=${WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL}
+    restart: unless-stopped # restarts container unless we explicitly stop it

--- a/docker-compose-deploy-dev.yml
+++ b/docker-compose-deploy-dev.yml
@@ -10,9 +10,11 @@ services:
     environment:
       - NODE_ENV=production
       - DATABASEURI=mongodb://${dbUsernameDev}:${dbPasswordDev}@${dbAddress}/${dbName}
-      - ACTIVATE_EMAIL=${ACTIVATE_EMAIL}
-      - MAILGUN_API_KEY=${MAILGUN_API_KEY}
-      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
+      - ACTIVATE_EMAIL=${ACTIVATE_EMAIL} # string value to turn on emails
+      - RESET_URI=${RESET_URI} # uri to tell user where to reset their password
+      - FROM_HEADER=${FROM_HEADER} # from header, shows subject and sender address
+      - MAILGUN_API_KEY=${MAILGUN_API_KEY} # mailgun api
+      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN} # mailgun key
     container_name: notadev
   watchtower:
     image: containrrr/watchtower

--- a/docker-compose-deploy-dev.yml
+++ b/docker-compose-deploy-dev.yml
@@ -14,3 +14,14 @@ services:
       - MAILGUN_API_KEY=${MAILGUN_API_KEY}
       - MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
     container_name: notadev
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    # check for new image every 60 secs and only watch watchtower and notadev containers
+    # remove old images after updating watched containers
+    command: watchtower notadev --interval 60 --cleanup
+    # provide slack web hook url to get notifications when containers update
+    environment:
+      - WATCHTOWER_NOTIFICATIONS=slack
+      - WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL=${WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL}

--- a/docker-compose-deploy-dev.yml
+++ b/docker-compose-deploy-dev.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  notadev:
+    image: notaorg/nota-dev:2b28271
+    command: node bin/www
+    ports:
+     - "3001:3000" # host:container
+     #- "27017:27017"
+     #- "27018:27018"
+    environment:
+      - NODE_ENV=production
+      - DATABASEURI=mongodb://${dbUsernameDev}:${dbPasswordDev}@${dbAddress}/${dbName}
+      - ACTIVATE_EMAIL=${ACTIVATE_EMAIL}
+      - MAILGUN_API_KEY=${MAILGUN_API_KEY}
+      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
+    container_name: notadev

--- a/docker-compose-deploy-dev.yml
+++ b/docker-compose-deploy-dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   notadev:
-    image: notaorg/nota-dev:2b28271
+    image: notaorg/nota-dev:latest
     command: node bin/www
     ports:
      - "3001:3000" # host:container

--- a/docker-compose-deploy-dev.yml
+++ b/docker-compose-deploy-dev.yml
@@ -23,7 +23,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     # check for new image every 60 secs and only watch watchtower and notadev containers
     # remove old images after updating watched containers
-    command: watchtower notadev --interval 60 --cleanup
+    # this compose file will have the one watchtower image to control all of the various
+    # related nota containers
+    command: watchtower notadev notaprod --interval 60 --cleanup
     # provide slack web hook url to get notifications when containers update
     environment:
       - WATCHTOWER_NOTIFICATIONS=slack

--- a/docker-compose-deploy-prod.yml
+++ b/docker-compose-deploy-prod.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  notaprod:
+    image: notaorg/nota-prod:latest
+    command: node bin/www
+    ports:
+     - "3000:3000" # host:container
+     #- "27017:27017"
+     #- "27018:27018"
+    environment:
+      - NODE_ENV=production
+      - DATABASEURI=mongodb://${dbUsernameProd}:${dbPasswordProd}@${dbAddress}/${dbName}
+      - ACTIVATE_EMAIL=${ACTIVATE_EMAIL} # string value to turn on emails
+      - RESET_URI=${RESET_URI} # uri to tell user where to reset their password
+      - FROM_HEADER=${FROM_HEADER} # from header, shows subject and sender address
+      - MAILGUN_API_KEY=${MAILGUN_API_KEY} # mailgun api
+      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN} # mailgun key
+    container_name: notaprod # restarts container unless we explicitly stop it
+    restart: unless-stopped

--- a/docker-notes.md
+++ b/docker-notes.md
@@ -19,3 +19,7 @@
 ### Run the deployed image with a command to start the application
 
 `docker run <image-id> node bin/www`
+
+### Enter interactive mode with bash with docker-compose
+
+`sudo docker-compose run <service-name> bash`


### PR DESCRIPTION
### What does this PR do?

This PR provides the two docker-compose files that describes how dev and prod of Nota is deployed and updated on the server.

### Additional info?

We are aware that travis automatically sends dev and prod images to our docker repositories. Our compose files have watchtower to automatically pull the corresponding dev and prod images and updates the containers on the server. I have used the Slack notification feature and internally provided a Rocket Chat webhook so that I will be notified when the containers on the servers updates to a newer image.

Merging this PR will help us test if the CD process of our workflow is working as expected. If so, we should be able to then close the issue #61 .

### What issue is this PR related to?

This PR is related to issue #118 and #61 

close #118 