### PR TITLE
chore(travis-ci): update travis yml build environment configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: linux
 dist: bionic
-language: minimal
+language: shell
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: required
-dist: trusty
+os: linux
+dist: bionic
 language: minimal
 
 services:


### PR DESCRIPTION
### What does this PR do?

This PR does the following:
- updates environment from 16.04 to 18.04
- removes the deprecated `sudo: required` key-value pair
- sets `os: linux`

### Which issues does this PR relate to?

This PR is related to #134 

close #134 