### PR TITLE
chore(github-action): node 8.x to 10.x for eslint workflow

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -16,7 +16,7 @@ jobs:
     # This step adds node setup with version 8
     - uses: actions/setup-node@v1
       with:
-        node-version: '8.x'
+        node-version: '10.x'
     - name: Install Dependencies
       run: npm install
     - name: Run ESLint

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     # This step checks out a copy of your repository.
     - uses: actions/checkout@v1
-    # This step adds node setup with version 8
+    # This step adds node setup with version 10
     - uses: actions/setup-node@v1
       with:
         node-version: '10.x'


### PR DESCRIPTION
### What does this PR do?

Updates NodeJS to version 10.x inside the GitHub Actions Eslint Workflow.

### Which issue is this PR related to?

This PR is related to issue #137 

close #137 