### PR TITLE
fix(emails): correct how the reset email generates the reset link

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -20,6 +20,6 @@ module.exports = {
 	activate_email: process.env.ACTIVATE_EMAIL || 'false',
 	mailgun_api_key: process.env.MAILGUN_API_KEY || 'place-holder-apiKey',
 	mailgun_domain: process.env.MAILGUN_DOMAIN || 'place-holder-domain',
-	reset_uri: process.env.RESET_URI || 'https://placeholder.com/reset/',
+	reset_uri: process.env.RESET_URI || 'https://placeholder.com',
 	test_email: process.env.TEST_EMAIL || 'user1@test.com'
 };

--- a/services/mailgun.js
+++ b/services/mailgun.js
@@ -9,7 +9,7 @@ module.exports.forgot_email = function(req, res) {
 	let data = JSON.parse(JSON.stringify(config.get('forgot_email_data')));
 	data.to = req.body.email;
 	data.text = data.text + '\nThis is your reset token ' + req.body.rtoken +
-  '\nVisit ' + reset_uri  + '/#/forgot to reset your password.';
+  '\nVisit ' + reset_uri + '/#/forgot to reset your password.';
 	if(activate_email === 'true'){ // for unit tests or for some other reason would like to deactive emails
 		mailgun.messages().send(data).then(function(){
 			// console.log(body); debugging purposes only

--- a/services/mailgun.js
+++ b/services/mailgun.js
@@ -9,7 +9,7 @@ module.exports.forgot_email = function(req, res) {
 	let data = JSON.parse(JSON.stringify(config.get('forgot_email_data')));
 	data.to = req.body.email;
 	data.text = data.text + '\nThis is your reset token ' + req.body.rtoken +
-  '\nVisit ' + reset_uri + req.body.email + ' to reset your password.';
+  '\nVisit ' + reset_uri  + '/#/forgot to reset your password.';
 	if(activate_email === 'true'){ // for unit tests or for some other reason would like to deactive emails
 		mailgun.messages().send(data).then(function(){
 			// console.log(body); debugging purposes only

--- a/services/mailgun.js
+++ b/services/mailgun.js
@@ -9,7 +9,7 @@ module.exports.forgot_email = function(req, res) {
 	let data = JSON.parse(JSON.stringify(config.get('forgot_email_data')));
 	data.to = req.body.email;
 	data.text = data.text + '\nThis is your reset token ' + req.body.rtoken +
-  '\nVisit ' + reset_uri + '/#/forgot to reset your password.';
+  '\nVisit ' + reset_uri + '/#/reset to reset your password.';
 	if(activate_email === 'true'){ // for unit tests or for some other reason would like to deactive emails
 		mailgun.messages().send(data).then(function(){
 			// console.log(body); debugging purposes only


### PR DESCRIPTION
### What does this PR do?

This pull requests fixes the reset link that is sent to users when requesting a password reset.
Note that the uri path is `/#/reset`.

### Additional info

I have tested the changes and the emails I received in my inbox looks good.

### Which issue is this PR related to?

This PR is related to issue #128 

close #128 