### PR TITLE
feat(watchtower): change polling interval to 1hr

### DIFF
--- a/docker-compose-deploy-dev.yml
+++ b/docker-compose-deploy-dev.yml
@@ -21,11 +21,11 @@ services:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    # check for new image every 60 secs and only watch watchtower and notadev containers
+    # check for new image every 3600 secs (1hr) and only watch watchtower, notadev, and notaprod containers
     # remove old images after updating watched containers
     # this compose file will have the one watchtower image to control all of the various
     # related nota containers
-    command: watchtower notadev notaprod --interval 60 --cleanup
+    command: watchtower notadev notaprod --interval 3600 --cleanup
     # provide slack web hook url to get notifications when containers update
     environment:
       - WATCHTOWER_NOTIFICATIONS=slack


### PR DESCRIPTION
### What does this PR do?

This PR modifies the polling interval to be one hr instead of 60 seconds (1 min).

### Any additional context?

As described in the related issue, DockerHub is changing their rate limits. To avoid any issues with pulling, after some thought, I determined it was okay to have our deployment to check for new images every hour. This will not give us immediate continuous deployment but we can still ensure we have it.

This has led me to think about no longer using Watchtower and create my own webhook that I can call to update the images on the server once a new one is available. This will be down the road however.

### How were the changes in this PR tested if applicable?

The current interval command has been working with no issue. We are just changing the duration.

### Any issues that are related to this PR?

This PR is related to issue #221 

close #221
