### PR TITLE
ci(github-actions): update eslint.yaml to use newer ubuntu version and upgrade actions versions

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -9,14 +9,14 @@ on: [push, pull_request]
 jobs:
   lint:
     name: Linter # Job name
-    runs-on: ubuntu-16.04 # Run on Ubuntu version 16.04.
+    runs-on: ubuntu-20.04 # Run on Ubuntu version 20.04.
     steps:
     # This step checks out a copy of your repository.
-    - uses: actions/checkout@v1
-    # This step adds node setup with version 10
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    # This step adds node setup with version 14
+    - uses: actions/setup-node@v2
       with:
-        node-version: '10.x'
+        node-version: '14.x'
     - name: Install Dependencies
       run: npm install
     - name: Run ESLint


### PR DESCRIPTION
### What does this PR do?

This PR updates the Ubuntu version for the linter workflow to 20.04. It also updates the node version to be 14 to be consistent with the node version Nota is using. The "checkout" action has also been upgrade to version 2.

### Any additional context?

N/A

### How were the changes in this PR tested if applicable?

Changes were tested here https://github.com/jaylenw/nota/runs/3639000560

### Any issues that are related to this PR?

This PR is related to issue #320 

close #320 
