### PR TITLE
fix(mongoose): replace deprecated functions w/ deleteOne & updateOne functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3166,7 +3166,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {

--- a/routes/users.js
+++ b/routes/users.js
@@ -168,7 +168,7 @@ router.post('/forgot', function(req, res, next) {
 				};
 
 				let updateCmd = { $set: updatedUser };
-				User.update(matchUser, updateCmd).exec(function(err, user){
+				User.updateOne(matchUser, updateCmd).exec(function(err, user){
 					if(err){
 						res.status(500).send('Error reading database!');
 					} else if(!user) {
@@ -216,7 +216,7 @@ router.post('/reset/:email', function(req, res, next) {
 				};
 
 				let updateCmd = { $set: updatedUser };
-				User.update(matchUser, updateCmd).exec(function(err, user){
+				User.updateOne(matchUser, updateCmd).exec(function(err, user){
 					if(err){
 						res.status(500).send('Error reading database!');
 					} else if(!user) {

--- a/services/sessions.js
+++ b/services/sessions.js
@@ -61,7 +61,7 @@ exports.generateSession = function(accountId, type, success, fail) {
 exports.deleteSession = function(token, success, fail) {
 	Session.findOne({
 		token: {$eq: token}
-	}).remove(function(err){
+	}).deleteOne(function(err){
 		if(err) fail(err);
 		else success();
 	});


### PR DESCRIPTION
### What does this PR do?

This PR replaces the `remove()` and `update()` mongoose functions with `deleteOne()` and `updateOne()` as they are now deprecated.

`package-lock.json` was modified to add a security patch.

### Any additional context?

Mongoose was updated so I referred to https://mongoosejs.com/docs/api/model.html#model_Model.remove and https://mongoosejs.com/docs/api/model.html#model_Model.update to replace the deprecated functions.

### How were the changes in this PR tested if applicable?

The changes were tested by running the CI tests.

### Any issues that are related to this PR?

This PR is related to issue #341 

close #341
